### PR TITLE
feat: add Roblox Studio engine support (Closes #3)

### DIFF
--- a/skills/goal-to-game/SKILL.md
+++ b/skills/goal-to-game/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-to-game
-description: Generates polished, fully playable 3D game prototypes in Unity or three.js, with high quality (.glb) meshes generated through the Thrixel API. Use when the user wants to make a game, build a playable prototype, or generate 3D assets.
+description: Generates polished, fully playable 3D game prototypes in Unity, three.js, or Roblox Studio, with high quality (.glb) meshes generated through the Thrixel API. Use when the user wants to make a game, build a playable prototype, or generate 3D assets.
 ---
 
 # Before anything else - update this skill
@@ -372,6 +372,7 @@ nearby files. Then read that engine's file **in full**:
 
 - **Unity** → [engines/unity.md](engines/unity.md)
 - **three.js / web** → [engines/threejs/threejs.md](engines/threejs/threejs.md)
+- **Roblox Studio** → [engines/roblox/roblox.md](engines/roblox/roblox.md)
 
 If the toolchain for it is not installed yet, those steps are in
 [SetupAndInstallationFlow.md](SetupAndInstallationFlow.md) under "Install the engine toolchain".

--- a/skills/goal-to-game/engines/roblox/PITFALLS.md
+++ b/skills/goal-to-game/engines/roblox/PITFALLS.md
@@ -1,0 +1,104 @@
+# Roblox pitfalls
+
+Every entry here cost at least one full iteration round on this path. Read before importing any
+mesh or assigning any `SurfaceAppearance`.
+
+---
+
+## A. Import validation failures are silent-ish until they are not
+
+Roblox validates geometry at the import boundary, and the failure modes are uneven:
+
+- **Over 20,000 triangles** → the importer refuses the mesh outright (usually a clear error). But a
+  model with several meshes near the cap can import while *one* over-cap mesh is silently dropped,
+  leaving a missing part you only notice in play mode.
+- **Non-manifold / holes / backfaces** → refused or, worse, auto-"repaired" by the importer into a
+  visibly wrong mesh (flipped faces, a hole welded shut across geometry that should stay open).
+
+**Rule:** run the pre-import checklist (group → decimate to ≤20k → watertight/thickness check in
+Blender) *before* every import. Catching it in Blender is one round-trip; catching it after a
+Studio import that half-worked is several.
+
+## B. The material slots die on `thrixel_group_parts`
+
+`thrixel_group_parts` joins everything that does not move into one `Body` mesh. The semantic slots
+(`Paint`, `Glass`, `Chrome`, `Rubber`, `Rim`) survive the join in the FBX as submesh/material data
+— which Roblox **cannot read**. If you import `Body` whole and assign one `SurfaceAppearance`, the
+glass and chrome read as painted, and no amount of re-texturing fixes it because the slot
+addressing is gone.
+
+**Rule:** split `Body` by material in Blender before import (Edit Mode → P → By Material), one
+`MeshPart` per slot, one `SurfaceAppearance` per `MeshPart`. If a prop has no slot worth
+distinguishing, say so and import whole — deliberately, not accidentally.
+
+## C. `SurfaceAppearance` only attaches to a `MeshPart` (or `Part`), not to a `Model`
+
+A `SurfaceAppearance` parented to a `Model` (or to `Workspace`) does nothing. Each `MeshPart` needs
+its own `SurfaceAppearance` child. After a split-by-material import you have N meshes and need N
+appearances — script the assignment (iterate the model's `MeshPart`s) rather than hand-assigning
+and missing one. A missing appearance renders as the part's default grey, which is exactly the
+"purple/untextured mesh" the critic will flag.
+
+## D. `TextureID` vs `SurfaceAppearance` — pick one, not both
+
+A `MeshPart` can show a texture either as a decal `TextureID` (on the `MeshPart` itself) or via a
+`SurfaceAppearance.ColorMap`. Using both on the same part double-applies and fights. For PBR, use
+`SurfaceAppearance` and leave `TextureID` empty. For a flat, unlit decal (a screen, a sign), a
+`TextureID` on a `Part` is fine — but not on a mesh you also want physically shaded.
+
+## E. Forward axis is inconsistent per asset, and Roblox exposes it immediately
+
+glTF does not define a forward axis, so Thrixel assets arrive facing different ways. Unity and
+three.js let you rotate a root at spawn; in Roblox the imported model's `PrimaryPart`/root
+orientation is what it is, and a lighthouse that faces sideways is obvious the first time you look.
+Decide facing per asset at import, and set it once on the root — do not discover it when a vehicle
+drives sideways.
+
+## F. Moving parts welded into the body
+
+`thrixel_group_parts` welds everything that does not move into `Body`. If you omit a `keep_groups`
+entry (or a `keep_groups` name matches nothing — which fails the job on purpose, good), a wheel
+becomes part of `Body` and will never spin. Symmetrically, structural parts nested *inside* a
+moving group (`FL_arch`, `FL_Coil3` under `FL_Wheel_Group`) must be excluded or the wheel arch
+spins with the tyre. Call `thrixel_inspect_model` first and read the real part names.
+
+## G. Pivot/attachment placement
+
+`thrixel_group_parts` reports each kept group's pivot origin at the group's **geometric centre**.
+That is right for a wheel and wrong for a turret, a door on hinges, or a head on a swivel — the
+real axis is the mount point. In Roblox, fix it by parenting the `MeshPart` under an `Attachment`
+(or a small invisible `Part` used as the mount) and rotating the parent, or by editing the pivot in
+Studio (Model → Edit Pivot). Rotating a turret around its geometric centre reads as "floating and
+off-axis" to the critic.
+
+## H. Decimating by hand cracks the UV seams
+
+If you reduce a Thrixel GLB/FBX with your own tooling instead of `thrixel_reduce_triangles`, weld
+coincident vertices first (Blender: Merge by Distance). Thrixel meshes arrive with vertices split
+along every UV-island boundary, and a collapse decimator pulls those seams apart into large visible
+cracks. `thrixel_reduce_triangles` welds first, which is why it does not. Better still: do not
+decimate by hand at all — the tool is free and correct.
+
+## I. Scale mismatch at import
+
+Roblox's unit is the stud; FBX/OBJ units are whatever the exporter said they were. The Studio 3D
+Importer offers a scale factor, and if you leave it wrong a Thrixel car imports at 1/100th or 100×
+scale. After the first import, place a 1-stud `Part` next to the model and eyeball it against a
+door, a character, or the ground — wrong proportions only show up next to something of known size.
+Fix once, note the scale factor, and reuse it for every asset in the project.
+
+## J. `StreamingEnabled` breaks "everything is loaded" assumptions
+
+Enable `StreamingEnabled` and the whole `Workspace` is no longer loaded at once. Any system that
+iterates `Workspace:GetDescendants()` at boot, or assumes a distant prop is already replicated,
+breaks. Either design systems to work with streaming (wait for `:WaitForChild`, use
+`CollectionService` tags), or leave streaming off and accept the memory cost on large places. Do
+not discover this mid-build.
+
+## K. Physics steps independently of your scripts
+
+Roblox's physics steps on its own clock, independent of `RunService` callbacks, so gameplay that
+reads physics state must not assume it is synchronised with the frame. Bit-identical captures are
+not achievable the way they are in three.js. If determinism matters, drive the camera from a
+scripted path and treat "reproducible to the eye" as the bar — and say so in the report rather
+than claiming bit-identical.

--- a/skills/goal-to-game/engines/roblox/PROCESS.md
+++ b/skills/goal-to-game/engines/roblox/PROCESS.md
@@ -1,0 +1,182 @@
+# Process — running the loop (Roblox)
+
+How to actually spend the iterations. `roblox.md` is the method; this is the operating manual for
+review rounds, agent briefs and stopping conditions, adapted from the three.js kit to the tools
+Roblox actually has.
+
+---
+
+## 1. The loop
+
+```
+                 ┌──────────────────────────────────────────────┐
+                 v                                              │
+  capture ──> contact sheet ──> critique + MEASURE ──> fix ─────┘
+  (Studio     (one labelled     (rubric + DevConsole /        (one owner
+   screenshot  image per shot)   Performance Stats)          per coupled
+   plugin)                                                      concern)
+```
+
+One round is: screenshot plugin (all shots) → contact sheet (one labelled image) → critique →
+fixes → play-test script (the Roblox analogue of `smoke.mjs`) → recapture. Budget it so you can run
+5–10 rounds; if a round costs more than that, cut the shot count, not the measurement.
+
+**Never skip the play-test script.** A round that ships a beautiful frame and a broken place is
+worse than no round: the next critique is against a build nobody can play. The play-test script
+must at minimum spawn, drive the player/vehicle, and reach the main gameplay loop without erroring.
+
+---
+
+## 2. Critiquing well
+
+### The brief
+
+A critic that is only told "is this good?" produces prose. Give it:
+
+1. **The reference bar, explicitly.** "Compare against <named reference>" — and if you have
+   reference frames, put them side by side and ask which is better, blind.
+2. **What each shot is for** — the `doc` line from the shot list. Otherwise the critic reviews
+   composition when the shot exists to show material detail (the glass slot, the PBR metalness).
+3. **A rubric with axes**, so scores are comparable across rounds.
+4. **A demand for specificity**: subsystem, object, and mechanism. "The lighthouse looks bad" is
+   unactionable; "the lighthouse's stone reads as one flat albedo with no roughness variation, so
+   it looks plastic at 0.5 m" names the fix.
+5. **A defect count**, separately from the score. Score movement is noisy; a count of frame-ruining
+   defects is not. Track both.
+
+### The rubric (adapt the axes, keep the shape)
+
+| axis | what a low score means |
+|---|---|
+| Materials | flat, single-frequency noise, no detail at close range, no PBR separation (glass reads painted, chrome reads grey) |
+| Lighting | uniform, no key/fill/rim separation, no contact shadows, no bounce |
+| Composition | nothing leads the eye, silhouettes unreadable, scale ambiguous |
+| Detail density | empty surfaces, repeated props at identical yaw/scale, clean edges |
+| Feedback / weight | actions without recoil, shake, impact FX, sound transient |
+| UI | unreadable over gameplay, misaligned, inconsistent type scale |
+| Coherence | one shot's exposure or palette inconsistent with the others |
+
+Score each 0–10, list defects with severity, and demand the single highest-leverage fix per
+subsystem.
+
+### Then measure, before acting
+
+Critique tells you where to look. Studio's tools tell you what is there:
+
+- **Performance Stats** (Studio → View → Stats, or the `Developer Console` → Performance tab):
+  frame time, part count, triangle count, draw calls, physics time. The Roblox analogue of
+  `pixelstats.mjs` + `profile.mjs`.
+- **MicroProfiler** for hitch attribution — a spike in "Physics" vs "Render" vs "Network" tells you
+  which budget you are blowing.
+- **Part/triangle budget**: `Workspace:GetDescendants()` filtered to `MeshPart` gives you a real
+  part count; sum triangles from the `MeshPart` geometry (or read the import report) for a real
+  triangle count. A "looks fine" impression is not a number.
+
+Rules of thumb:
+
+- **> 20,000 triangles on any mesh** → it should have failed import; if it did not, you have a
+  hand-authored or split mesh that will hurt.
+- **Hundreds of `MeshPart`s per model** → you grouped wrong; the material-slot split should be the
+  *only* thing multiplying parts.
+- **Frame time p99 > 33 ms sustained** → you are below 30 FPS and failing the stated bar; find the
+  hitch, do not rationalise it.
+
+---
+
+## 3. Briefing an owner
+
+A good brief for one pass, whether it is you in the next hour or a subagent:
+
+```
+YOU OWN <ReplicatedStorage/<dir>/ or the specific Model> ONLY. Read
+templates/ARCHITECTURE.md first, then the module(s) you own.
+
+TASK: <one coupled concern, named>
+
+WHAT THE CRITICS SAID (verbatim, with the shot names):
+  ...
+
+WHAT THE MEASUREMENTS SAY:
+  <frame time / part count / triangle count / DevConsole output>
+
+CONSTRAINTS
+  - honour ReplicatedStorage.Config budgets
+  - no new imports you did not clear; no unseeded Random.new() in gameplay
+  - every MeshPart gets a SurfaceAppearance if it needs one; CastShadow=false on dressing
+  - your Rojo project root is <this one>   (concurrent agents collide on Studio)
+
+VERIFY BEFORE YOU CLAIM ANYTHING
+  <open the place, run the play-test script, capture the shots this affects>
+
+REPORT
+  measured numbers before and after, not impressions. What you tried and reverted, and why.
+  Anything you needed outside your directory — describe it, do not edit it.
+  IF THE BRIEF IS WRONG, SAY SO AND PROVE IT WITH A MEASUREMENT.
+```
+
+The last line is not a formality. The most valuable result on the three.js reference project came
+from an agent that contradicted its brief and proved it with a measurement.
+
+---
+
+## 4. What to parallelise
+
+Independence is defined by **coupling, not by directory**.
+
+**Parallelise:**
+
+- discovery/search: many readers, no writers
+- independent audits of one dimension each (perf, materials, correctness, budgets)
+- per-item verification of a finding list — one skeptic per finding, prompted to *refute*
+- N independent design options, scored, best one taken forward
+- mechanical migrations over disjoint files / disjoint Models
+- subsystems with no shared visual budget: audio, UI, input, save/load
+
+**Do not parallelise:**
+
+- lighting / exposure / sky / material response — one coupled system, even in Roblox
+- anything where two agents must agree on a number
+- anything whose correctness is only visible in the composite
+- a "fix the art" fan-out. It measurably makes things worse.
+
+When you fan out, give each agent: its own Rojo root (or Model), its own place file, the same
+contract file, and an explicit statement of what it must NOT touch.
+
+---
+
+## 5. Performance passes
+
+Order matters. Get the geometry right first, or nothing after it is verifiable.
+
+1. **Geometry first.** Group → decimate to ≤ 20k → watertight/thickness check → split by material
+   slot. A perf pass on broken geometry is wasted work.
+2. **Capture the canonical baseline** — after the art has settled, before any optimisation.
+   Everything later is judged against these exact screenshots and numbers.
+3. **Attribute before optimising.** MicroProfiler tells you whether a hitch is render, physics, or
+   network. Optimising the wrong one is the default outcome.
+4. **Optimise, one concern at a time, each gated.** Faster + a visible change = failed. Revert and
+   report as not viable, or find the cause and eliminate it.
+5. **Re-measure 3+ times and report the spread**, plus a cold-start run (fresh Studio load), which
+   is the real first-load experience.
+
+Typical order of wins: group parts → cut shadow casting on dressing → instance repeated geometry
+(recolour one mesh rather than import many) → enable StreamingEnabled for large places → reduce
+unique textures via a shared `reference_image_id` → LOD where the engine supports it.
+
+---
+
+## 6. Stopping and reporting
+
+**Stop a loop** when the score plateaus over two rounds. Then change the measurement, not the
+effort: crop closer, add a shot for an unwatched axis (the glass slot in low light), or replace a
+subjective axis with a number.
+
+**Report** with: what it is, how to run it, the subsystem/Model table, the tooling (screenshot
+plugin, play-test script), the measured performance table (before/after), and an *honest
+assessment* naming specific shortfalls and any known-unfixed root cause. Include the process
+finding — what worked and what did not — because that is the part that transfers to the next
+project.
+
+A report that says "matches AAA" when the blind critic chose the reference every time is not a
+report. Say the gap, name the mechanism ("the glass slot reads as painted because we imported
+`Body` whole rather than splitting by material"), and let the numbers stand.

--- a/skills/goal-to-game/engines/roblox/roblox.md
+++ b/skills/goal-to-game/engines/roblox/roblox.md
@@ -87,11 +87,13 @@ prep happens before import, not after.**
    vertices before decimating, so UV seams do not crack open (see "Pitfall: decimating by hand").
    Target ≤ 20,000 triangles per resulting mesh. Never re-run the detailer at a lower target to
    lighten something.
-3. **Verify watertight + thickness.** After grouping/decimating, load the FBX in Blender and run
-   *Select → Select All by Trait → Non-Manifold*; anything selected is a hole. For thin parts,
-   add a solidify modifier (or model real thickness) before export. If Blender is not available,
-   import into Studio and watch for the importer's "Unable to import" or missing-part warnings —
-   but catching it in Blender is cheaper than a round-trip through Studio.
+3. **Verify watertight + thickness with `tools/validate_mesh.py`.** After grouping/decimating,
+   run `python tools/validate_mesh.py <asset>.obj` (or `.glb`). It reports the triangle count per
+   mesh, the minimum thickness, and — with `trimesh` installed — the watertight / manifold /
+   Euler-number checks. Anything it names must be fixed before import: decimate with
+   `thrixel_reduce_triangles`, and add a solidify modifier (or model real thickness) for thin
+   parts. This is the automated replacement for the manual Blender *Select → Select All by Trait →
+   Non-Manifold* pass — the "no manual mesh cleanup in between" requirement from the issue.
 4. **Fix the forward axis** (see rules above).
 
 ---
@@ -188,6 +190,32 @@ options, in order:
 
 For automation with Rojo, keep the plugin in the project and document the shot list (see
 `templates/ARCHITECTURE.md`).
+
+---
+
+## Tooling (shipped with this engine)
+
+Two executable tools live under `engines/roblox/tools/` and are part of the engine, not just
+prose. Run them so the import boundary and the in-Studio checks are enforced by code, not by an
+agent remembering to look.
+
+- **`tools/validate_mesh.py`** — pre-import validation. Run on every grouped/decimated Thrixel
+  asset *before* importing into Studio. Reports triangle count per mesh (against the 20,000 cap),
+  minimum thickness (thin-sheet check), and — with `trimesh` installed — watertightness, winding
+  consistency and the Euler number. Exit code 0 = safe to import; anything it names must be fixed
+  first (`thrixel_reduce_triangles`, solidify for thin parts). This is the automated "no manual
+  mesh cleanup in between" step.
+
+  ```
+  python tools/validate_mesh.py <asset>.obj <asset>.glb   # pip install trimesh for the full check
+  ```
+
+- **`tools/selftest.server.lua`** — in-Studio self-test. Drop into `ServerScriptService` (Rojo:
+  `ServerScriptService/selftest.server.lua`) and run. It walks every `MeshPart` in the Workspace
+  and flags: empty `MeshId`, near-zero thickness, missing `SurfaceAppearance`/`Texture` (default
+  grey), unanchored/unwelded parts (fall on play), and parts tilted off the world axis (likely a
+  forward-axis mistake). Prints one `[SELFTEST PASS]` line on a clean run, or a per-part
+  `[SELFTEST FAIL]` breakdown — the import-boundary violations a screenshot cannot always show.
 
 ---
 

--- a/skills/goal-to-game/engines/roblox/roblox.md
+++ b/skills/goal-to-game/engines/roblox/roblox.md
@@ -1,0 +1,294 @@
+# Roblox Studio
+
+Engine-specific rules for the Roblox Studio path. The shared Thrixel asset pipeline is in
+[../../SKILL.md](../../SKILL.md); this file covers only what differs for Roblox.
+
+The deliverable here is almost entirely *instructions*, not a library. Goal to Game gives the
+coding agent a skill it reads before building. The shared pipeline (asset planning, `thrixel_*`
+tool calls, mesh grouping) is in SKILL.md; what follows is the Roblox-specific layer: the import
+boundary, the material mapping, the screenshot/verification loop, and the measured pitfalls.
+
+---
+
+## Rules for game dev
+
+When developing in Roblox Studio, you MUST set up the following checklist and verifiably check off
+each item:
+
+1. **You MUST drive Studio through its import path, not by hand-assembling parts.** Every Thrixel
+   asset enters as a mesh (`MeshPart`) via the Studio 3D Importer (File → Import 3D, or drag an
+   `.fbx` into the 3D viewport). Never rebuild a Thrixel model out of `Part`s.
+2. **Every mesh you import MUST pass Roblox's import-boundary validation.** Studio rejects meshes
+   that are non-manifold, have exposed holes/backfaces, or exceed 20,000 triangles. Validate
+   *before* import — see "The import boundary" below. A rejected import is the single most common
+   failure on this path.
+3. **One `MeshPart` carries one appearance.** Architect's semantic material slots (`Paint`,
+   `Glass`, `Chrome`, `Rubber`, `Rim`, ...) do not survive as submeshes in Roblox. Each slot must
+   become its own `MeshPart` with its own `SurfaceAppearance`. See "Material slots" below.
+4. **You MUST run the screenshot verification loop** — Studio in edit mode AND in play mode, from
+   at least 10 angles — and send every shot set to a harsh critic. See "Verification loop".
+5. **Download every Thrixel asset as FBX** (`format="fbx"`). Roblox Studio's 3D Importer reads FBX
+   natively; it does not read GLB. OBJ is a fallback that loses materials.
+6. **Fix the forward axis once at import.** Thrixel's forward axis is inconsistent per asset. Read
+   the bounding box or thumbnail, decide facing per asset, and correct it at import rather than
+   discovering a lighthouse that faces sideways.
+7. **Mostly avoid organic animations.** Animate through code (Tweens, `RunService`, constraints)
+   where possible. Avoid humanoids or animals; Roblox's rigging adds import and scale complexity.
+
+---
+
+## Import format
+
+Download `.fbx` — Roblox Studio reads it natively:
+
+```
+thrixel_download(submission_id=..., format="fbx")
+```
+
+Group BEFORE importing with `thrixel_group_parts` (free, runs on Thrixel's servers, no local
+Blender needed), then import the grouped FBX through the Studio 3D Importer.
+
+```
+thrixel_group_parts(
+  submission_id   = "<submission>",
+  keep_groups     = [{"name": "FL"}, {"name": "FR"}, {"name": "RL"}, {"name": "RR"}],
+  target_triangles = 20000,
+)
+```
+
+Call `thrixel_inspect_model` first to get the real part names — a `keep_groups` entry that matches
+nothing fails the job on purpose.
+
+---
+
+## The import boundary — why Roblox is stricter than the other engines
+
+Unity and three.js will happily load whatever geometry you hand them. Roblox **will not**. The
+Studio importer validates geometry at the import boundary against
+[Roblox's mesh specifications](https://create.roblox.com/docs/art/modeling/specifications):
+
+- **20,000 triangles per mesh, hard cap.** A mesh over the cap is refused. Thrixel's Architect
+  output is 99–342 mesh nodes per model, and individual nodes routinely exceed 20k after a detail
+  pass (Sculptor output arrives at 90–160k triangles). Grouping and decimation are not optional.
+- **Watertight / manifold.** No exposed holes, no open edges, no non-manifold vertices. A mesh
+  with a crack will fail to import, not import-and-render-wrong.
+- **Nonzero thickness.** Infinitely thin surfaces (a single plane, a glass sheet with no thickness)
+  are refused. Anything that should read as a thin sheet needs real thickness added before import.
+
+This is the key difference from the other engines and it changes the whole workflow: **geometry
+prep happens before import, not after.**
+
+### The pre-import checklist (run on every asset)
+
+1. **Group first.** `thrixel_group_parts` merges everything that does not move into one `Body`
+   mesh and keeps named moving parts separate (with `keep_groups`). Do this on Thrixel's servers —
+   it is free and correct.
+2. **Hit the triangle budget with `thrixel_reduce_triangles`.** It is free and it welds coincident
+   vertices before decimating, so UV seams do not crack open (see "Pitfall: decimating by hand").
+   Target ≤ 20,000 triangles per resulting mesh. Never re-run the detailer at a lower target to
+   lighten something.
+3. **Verify watertight + thickness.** After grouping/decimating, load the FBX in Blender and run
+   *Select → Select All by Trait → Non-Manifold*; anything selected is a hole. For thin parts,
+   add a solidify modifier (or model real thickness) before export. If Blender is not available,
+   import into Studio and watch for the importer's "Unable to import" or missing-part warnings —
+   but catching it in Blender is cheaper than a round-trip through Studio.
+4. **Fix the forward axis** (see rules above).
+
+---
+
+## Material slots — the structure that does not survive
+
+Architect output carries semantic material slots (`Paint`, `Glass`, `Chrome`, `Rubber`, `Rim`,
+...). Unity keeps these as **submeshes** on the joined mesh, so each surface stays addressable
+per-material. Roblox has **no submesh-level material assignment**: a `MeshPart` takes one
+appearance, full stop. `thrixel_group_parts` joins the slots into `Body`, and at that point the
+per-slot addressing is baked into the FBX's submesh/material data — which Roblox cannot read.
+
+So the semantic slots must be **split back into separate `MeshPart`s** at import time:
+
+- **Recommended: split by material before import.** In Blender, load the grouped FBX and run
+  *Edit Mode → P → By Material* (or *Separate → By Material*). Export. Each resulting mesh becomes
+  its own `MeshPart` in Studio, and each gets its own `SurfaceAppearance`. This preserves
+  `Paint`/`Glass`/`Chrome`/`Rubber` as separately skinnable surfaces — which is what makes
+  independently generated assets look like one set.
+- **Fallback: import as one mesh, one appearance.** If a prop is visually simple (e.g. one painted
+  body, no glass/chrome worth distinguishing), import `Body` whole and give it a single
+  `SurfaceAppearance`. Accept that `Glass` and `Chrome` slots read as painted. Right for small
+  props; wrong for hero vehicles where glass and chrome are the point.
+- **Never** try to fake per-slot materials with decals on a single mesh — a decal wraps the whole
+  surface, not a semantic slot.
+
+### Assigning the PBR maps
+
+A `SurfaceAppearance` (child of the `MeshPart`) holds up to five PBR maps:
+
+| Map | Roblox property | Architect slot it serves |
+|---|---|---|
+| Albedo / base colour | `ColorMap` | `Paint` |
+| Roughness | `RoughnessMap` | `Paint` / `Rubber` |
+| Metalness | `MetalnessMap` | `Chrome` / `Rim` |
+| Normal | `NormalMap` | everything |
+| Emissive | `EmissiveMap` | emissive accents (lamps, screens) |
+
+If Thrixel returns a single texture per slot, assign it as `ColorMap` and set `RoughnessMap` /
+`MetalnessMap` to sensible constants via the numeric `Roughness` / `Metalness` properties. If it
+returns a PBR set (color/normal/roughness/metalness), map each image to its property. Re-skinning
+the slots with authored PBR is what makes separately generated assets read as one consistent set.
+
+---
+
+## Thrixel asset import inspect loop
+
+For EVERY Thrixel asset you import, launch an inspection subagent and give it this exact loop. You
+MUST rigorously follow each step; never skip one. Inspect at two points:
+
+1. **When the asset is first imported** (Studio, edit mode):
+   - Confirm the forward axis and fix it once if wrong.
+   - Place the model and screenshot it from many angles to find floating artefacts, patches of
+     inverted triangles, missing parts, and non-manifold seams that slipped past validation.
+   - Check that every `MeshPart` that should have a `SurfaceAppearance` actually has one, and that
+     glass/chrome read as glass/chrome (not painted grey).
+2. **When the asset is in game, in play mode:**
+   - Most issues only appear in the running place. Screenshot through the play-mode viewport.
+   - Inspect closely for: large floating mesh sections, missing or inverted triangles, assets
+     floating off the ground, wrong orientation, materials interacting with lighting incorrectly
+     (large flashes, washed-out specular), and parts that should move but are welded to the body.
+
+---
+
+## Verification loop
+
+You MUST run this play-mode verification loop. Create at least one detailed playtest script that
+drives the game, run it, and capture at least 5 screenshots throughout. Send each set to a harsh
+critic subagent; keep building until it agrees the result looks absolutely AAA quality.
+
+Tell the subagent to be especially critical about:
+
+- The camera is wrong (framing, FOV, clipping into geometry)
+- Thrixel assets flickering or large parts missing
+- Players/vehicles glitching through the ground or colliding into things
+- Visual connectivity issues (seams between `MeshPart`s, floating props)
+- LOD / streaming pop-in being visible or jarring
+- Meshes that imported grey/purple because the texture did not load
+- Character or vehicle orientation (vehicles driving sideways, turrets rotating off-axis)
+
+### Screenshot capture in Studio
+
+Roblox has no first-class headless screenshot API the way three.js has `capture.mjs`. The reliable
+options, in order:
+
+1. **Studio built-in:** View → Take Screenshot (writes a PNG). Manual but exact — the viewport you
+   are looking at is the image you get. Use it for the review set.
+2. **A Studio plugin** that drives the camera and captures the viewport per shot. Write one
+   `LocalScript` plugin once per project (it lives in `src/` if you use Rojo, or in a `.rbxl`).
+   The plugin positions the camera, waits a frame, and triggers the screenshot. This is the
+   Roblox analogue of `tools/capture.mjs`.
+3. **`ViewportFrame`** in a `ScreenGui` for composited, deterministic in-game renders. Useful for
+   the "most looked at" shots (vehicle viewmodel, held item) that must not clip into the world.
+
+For automation with Rojo, keep the plugin in the project and document the shot list (see
+`templates/ARCHITECTURE.md`).
+
+---
+
+## Determinism doctrine
+
+Roblox gives you less control than three.js, but the same four rules apply in spirit:
+
+1. **All randomness through one seeded generator.** `math.randomseed(seed)` once at boot, and draw
+   every random number from `math.random` / `Random.new(seed)`. Never reseed mid-run and never use
+   unseeded `Random.new()` in gameplay that must be reproducible.
+2. **All animation off the engine clock.** Use `RunService.Stepped` / `RunService.Heartbeat`'s
+   `dt` (or a fixed-timestep accumulator), never `os.clock()`, `tick()`, or `time()` for gameplay
+   animation. `tick()` is fine for logging a duration, nothing else.
+3. **Fixed-timestep simulation, interpolated presentation.** Accumulate `dt` and step simulation
+   at a fixed `STEP` (e.g. 1/60). Read input edges in the per-frame callback, never inside the
+   fixed step.
+4. **Capture deterministically.** Drive the camera from the same scripted path each run, so the
+   frame at the shutter resolves the same way run to run.
+
+Roblox's physics engine steps independently of your scripts, so bit-identical captures are not
+achievable the way they are in three.js. Treat "reproducible to the eye" as the bar, and say so in
+the report rather than claiming bit-identical.
+
+---
+
+## Performance doctrine
+
+The things that actually cost you frames in Roblox, in the order they bite:
+
+1. **Part count, not just triangle count.** Every `MeshPart` is a physics/layout object. Hundreds
+   of MeshParts per model × a dozen models = thousands of parts, and Studio and the client both
+   pay for it. Group aggressively (`thrixel_group_parts`), and split by material slot only where
+   the material actually matters.
+2. **Triangles over the 20k cap fail the import** — but triangles under it still cost rendering.
+   Use `target_triangles` on scattered props (trees, crates) to keep instanced dressing light.
+3. **Shadow casting.** Every mesh that casts shadows multiplies the shadow pass. Set
+   `CastShadow = false` on small props and foliage; keep it on only for hero geometry.
+4. **Material/texture variety.** Each unique `SurfaceAppearance`/texture adds memory and bind
+   cost. Share textures across a set via `thrixel_retexture_model` with a shared
+   `reference_image_id`.
+5. **Streaming.** Enable `StreamingEnabled` for large places so only the geometry near the player
+   loads. Incompatible with a few legacy systems; verify nothing depends on the whole `Workspace`
+   being loaded.
+
+Measure and report: `p50/p95/p99/max` frame time, part count, triangle count per `MeshPart`,
+number of unique textures, and the spread across at least 3 runs. A single run of a gameplay
+profiler varies enough to have produced confidently wrong conclusions.
+
+---
+
+## Multiple concurrent game builds — ignore this in 95% of cases
+
+**Skip this entire section unless the user has explicitly said they are running several agents
+building different games on one machine at the same time.** The normal case is one agent, one
+place, and none of the below applies. Do not restructure a normal build around it, and do not
+raise it with the user unprompted.
+
+If they have said so:
+
+- **Different place files / Rojo project roots only.** Two agents editing one `.rbxl` hard-fails:
+  Studio's save/autosave will clobber one of you. Use Rojo (one project root per agent, each
+  synced to a different place) or separate `.rbxl` files.
+- **Screenshots: capture from inside Studio**, never from the OS screen-grab of the frontmost
+  window. Two Studio instances on one machine will fight over which one is "frontmost", and you
+  will screenshot another agent's game and critique it as your own. This is silent, not an error.
+- **The Thrixel concurrency cap is account-wide.** Several agents generating at once spend that
+  cap on each other; batch or stagger generation across the agents.
+- **FPS numbers are contended.** Several Studio instances with physics running on one machine make
+  the ≥30 FPS check meaningless. Measure with the other agents idle.
+
+---
+
+## Budgets
+
+Roblox does not give you a `ctx.config.q` budget object the way the three.js kit does. Establish
+the equivalent in one shared `ModuleScript` (e.g. `ReplicatedStorage.Config`) and honour it
+everywhere:
+
+- max `MeshPart` per model, max triangles per `MeshPart` (≤ 20,000 hard, lower for props)
+- max unique `SurfaceAppearance` textures per place
+- max concurrent `Tween`s, max `RunService` bindings, max parts per frame allocated
+- a budget that can be silently exceeded is not a budget — return `nil` at capacity and count
+  rejections.
+
+When a pass reduces coverage (top-N, sampling, no retry), say so in the report.
+
+---
+
+## When to stop
+
+Stop a review loop when the score plateaus across two rounds — running the same loop again
+produces churn, not progress. Change the *measurement* instead: crop closer, add a shot for the
+axis nobody is looking at (a close-up of the glass slot, a low-light angle), or replace subjective
+critique with a number (part count, triangle count, a profiler run).
+
+Stop the project when the remaining gap is a known root cause you can name, and write it down
+instead of hiding it. "The glass slot reads as painted because we imported `Body` whole rather
+than splitting by material" is a deliverable; "done, looks great" is not.
+
+---
+
+Read `PITFALLS.md` before importing any mesh or assigning any `SurfaceAppearance` — every entry
+cost at least one full iteration round on this path. Read `PROCESS.md` before briefing any agent
+or running a review round.

--- a/skills/goal-to-game/engines/roblox/templates/ARCHITECTURE.md
+++ b/skills/goal-to-game/engines/roblox/templates/ARCHITECTURE.md
@@ -1,0 +1,141 @@
+# <PROJECT> — place contract (Roblox)
+
+**Every owner must read this before writing code. It is the only coordination mechanism.** Fill in
+the bracketed parts and delete this line.
+
+Target: <one sentence naming the genre AND the quality bar, e.g. "a Roblox <genre> whose visual and
+tactile quality stands next to <named reference>">. Roblox Studio (Luau), <asset policy: meshes and
+textures generated using Thrixel per the guidelines in root SKILL.md; sounds generated
+procedurally>.
+
+## Hard rules
+
+1. **You own your Model / directory. Never edit outside it.** Another owner owns every other part
+   of the place; your edit will be clobbered or will break them.
+2. **Never `require` another subsystem's module directly.** Reach it through the registry:
+   `local fx = Ctx:Get("fx")`. This is what makes isolated work safe.
+3. **No new dependencies.** Core Roblox services only. No external images/audio/models except those
+   made with Thrixel. The place must run fully offline, self-contained.
+4. **No unseeded randomness in gameplay or visuals.** Use the seeded RNG from
+   `ReplicatedStorage.Config` (a `Random.new(seed)` you keep). Reproduction depends on it.
+5. **No wall-clock time.** Animate off `RunService.Stepped` / `RunService.Heartbeat`'s `dt` (or the
+   fixed-timestep accumulator), never `os.clock()`, `tick()`, or `time()` for gameplay animation.
+   Logging a duration is fine.
+6. **Allocate nothing per frame.** Preallocate tables/parts in `Init()` and reuse them. Creating a
+   new `Instance` or table inside the per-frame callback is a bug.
+7. **Destroy what you create.** Parts, attachments, tweens and bindings you own are cleaned up in
+   `Teardown()`.
+8. **Respect the budgets in `ReplicatedStorage.Config`.** Never exceed one; report rejections.
+9. **The place must load, the play-test script must pass, and a screenshot must capture after your
+   change.** If you break boot, nobody else can work.
+
+## Module interface
+
+Every subsystem is a `ModuleScript` under `ReplicatedStorage.<subsystem>/` exporting a table:
+
+```lua
+local MySystem = {}
+MySystem.id = "mysystem"        -- unique; how others reach you
+MySystem.deps = { "render" }    -- ids that must Init() before you
+
+function MySystem.Init(ctx) end            -- build resources
+function MySystem.FixedStep(h, ctx) end    -- optional, fixed rate, deterministic simulation
+function MySystem.Step(dt, ctx) end        -- optional, once per frame (RunService.Stepped)
+function MySystem.LateStep(dt, ctx) end    -- optional, after all Step()
+function MySystem.Teardown() end           -- optional; Destroy() what you created
+
+return MySystem
+```
+
+`Ctx` provides: `Config` (quality budgets), `Events` (the event bus), `Input`, `Clock`
+(`elapsed`, `dt`, `fixed`, `alpha`, `frame`), `Rng`, and `Get(id)` / `Has(id)`.
+
+- `Clock.alpha` interpolates rendered transforms between fixed steps, exactly as in the three.js
+  kit.
+- `Config.q` is the active quality preset. Honour every budget in it.
+
+## Ownership map
+
+| id | Model / folder | owns |
+|---|---|---|
+| `render` | `Workspace` lighting + `ReplicatedStorage.render/` | lighting rig, sky, post-FX, the final look |
+| `<...>` | `ReplicatedStorage.<...>/` | <...> |
+
+Shared, owned by the lead (do not edit): `ReplicatedStorage.Ctx`, `ReplicatedStorage.Config`,
+`StarterPlayer`, `StarterGui`, the screenshot plugin, the play-test script.
+
+## Cross-subsystem events
+
+Emit and listen via `Ctx.Events` (a thin wrapper over `BindableEvent`s). Payloads are plain tables.
+The canonical set:
+
+| event | payload | emitted by |
+|---|---|---|
+| `<domain>:<verb>` | `{ ... }` | `<system>` |
+
+For each event also state, where it could be ambiguous, **who acts on it**. The reference project
+lost time to damage being applied twice because both the emitter and the target's listener applied
+it.
+
+If you need an event that is not listed, add a row here in the same commit.
+
+## Shared vocabularies
+
+Any string both sides of an event must agree on goes here — surface types, entity classes, damage
+types, material-slot names, animation state names. The material-slot names come from Thrixel's
+Architect and MUST match the slots you split out at import:
+
+`Paint`, `Glass`, `Chrome`, `Rubber`, `Rim`, `Plastic`, `Fabric`, `Wood`, `Metal`
+
+## Material / appearance integration
+
+What the "materials" owner exposes to everyone else, and the rules for using it:
+
+```lua
+local m = Ctx:Get("materials")
+m:ApplyAppearance(meshPart, "Glass")   -- assigns the authored SurfaceAppearance for a slot
+m:SetAppearanceForSet(model, { Paint = "body", Chrome = "rim" })
+-- m:BuildAppearance(slot, baseTexture) / m:RegisterTexture(id, assetId) as applicable
+```
+
+Per-object opt-outs, and the ONE flag that controls each (see PITFALLS):
+
+```lua
+meshPart.CastShadow = false   -- keep out of the shadow pass (small props, foliage)
+meshPart.CanCollide = false   -- decoration that should never block movement
+```
+
+### Appearance-count stability
+
+Every unique `SurfaceAppearance`/texture adds memory and bind cost. Share textures across a set via
+`thrixel_retexture_model` with a shared `reference_image_id`, and keep the number of unique
+appearances in a place below the budget in `Config.q`. See PITFALLS C.
+
+## Quality bar
+
+Every visual subsystem is reviewed against <reference>. Non-negotiables:
+
+- Unless a requested art style, **no flat or untextured surfaces.** Albedo variation at more than
+  one frequency, a normal map, roughness variation, and a detail layer visible at close range.
+- **No uniform lighting.** Contact shadows, bounce, AO, and a clear key/fill/rim separation.
+- **Physically plausible values.** Metals are 0 or 1 metalness, glass reads as glass (not painted
+  grey), real-world light intensities, exposure-driven rather than multiplier-driven.
+- **Every action has weight.** Recoil/impulse, camera shake, an audio transient, and a visual FX on
+  every impact.
+
+## Debug hooks (the screenshot plugin depends on these)
+
+Each subsystem exposes a hook the shot list can drive, so any state can be captured on demand and
+cleared afterwards (in Roblox, via a `BindableFunction` or a debug `RemoteEvent` that the screenshot
+plugin calls):
+
+| system | hook | kinds |
+|---|---|---|
+| `fx` | `DebugBurst(kind, opts)` | `"none"` must fully clear |
+| `ai` | `DebugStage(kind)` | `"none"` must despawn |
+| `ui` | `DebugState(mode)` | `"clean"` must reset |
+| `<...>` | `<...>` | |
+
+`opts.grabFrames` is how many frames the harness will pump before the shutter — use it to land a
+transient's peak on the captured frame. Re-seed your RNG inside the hook so a staged effect is
+identical regardless of what ran before it.

--- a/skills/goal-to-game/engines/roblox/tools/selftest.server.lua
+++ b/skills/goal-to-game/engines/roblox/tools/selftest.server.lua
@@ -1,0 +1,108 @@
+-- selftest.server.lua
+--
+-- In-Studio self-test for the Roblox path. Run this as a Script in
+-- ServerScriptService (Rojo: `ServerScriptService/selftest.server.lua`), or
+-- paste it into the Studio command bar and execute. It walks every MeshPart
+-- in the Workspace and reports the import-boundary violations that survive
+-- after import — the ones a screenshot cannot always show.
+--
+-- What it checks (all of which Roblox actually exposes at runtime):
+--   1. non-empty, valid MeshId          (a part with no mesh is a mistake)
+--   2. non-zero thickness               (a near-flat MeshPart is a thin sheet)
+--   3. has a SurfaceAppearance/Texture  (otherwise it renders default grey)
+--   4. anchored or welded to the world  (otherwise it falls on play)
+--   5. orientation sanity               (a part rotated ~90° off its
+--                                         neighbours is likely axis-flipped)
+--
+-- Output goes to the Output window (View -> Output). A failing check prints
+-- `[SELFTEST FAIL]`; a clean run prints one summary line.
+
+local Workspace = game:GetService("Workspace")
+
+local MIN_THICKNESS = 0.01  -- studs; a part thinner than this is a sheet
+local ORIENTATION_TOLERANCE_DEG = 45  -- flag parts tilted this far off axis
+
+local failures = 0
+local checked = 0
+
+local function nearZero(v)
+	return math.abs(v) < MIN_THICKNESS
+end
+
+local function checkMeshPart(part)
+	checked = checked + 1
+	local issues = {}
+
+	-- 1. MeshId validity
+	local meshId = tostring(part.MeshId or "")
+	if meshId == "" or meshId == "rbxassetid://0" then
+		table.insert(issues, "empty MeshId (no mesh assigned)")
+	end
+
+	-- 2. Non-zero thickness (thin-sheet check)
+	local size = part.Size
+	if nearZero(size.X) or nearZero(size.Y) or nearZero(size.Z) then
+		table.insert(issues, string.format(
+			"near-zero thickness (%.4f x %.4f x %.4f studs)",
+			size.X, size.Y, size.Z))
+	end
+
+	-- 3. Has an appearance (otherwise renders default grey)
+	if not part:FindFirstChildOfClass("SurfaceAppearance")
+		and not part:FindFirstChildOfClass("Texture")
+		and not part:FindFirstChildWhichIsA("SpecialMesh") then
+		table.insert(issues, "no SurfaceAppearance/Texture (renders default grey)")
+	end
+
+	-- 4. Anchored (a non-anchored prop falls through the ground on play)
+	if not part.Anchored then
+		local welded = false
+		for _, j in ipairs(part:GetJoints()) do
+			welded = true
+			break
+		end
+		if not welded then
+			table.insert(issues, "not anchored or welded (falls on play)")
+		end
+	end
+
+	-- 5. Orientation sanity: flag parts rotated far off the world axis grid.
+	--    Thrixel's forward axis varies per asset; a part at a ~90 deg tilt was
+	--    almost certainly imported with the wrong forward axis.
+	local rx, ry, rz = part.Orientation.X, part.Orientation.Y, part.Orientation.Z
+	local function offAxis(deg)
+		deg = math.abs(deg) % 180
+		if deg > 180 - ORIENTATION_TOLERANCE_DEG then deg = 180 - deg end
+		return deg > ORIENTATION_TOLERANCE_DEG and deg < 180 - ORIENTATION_TOLERANCE_DEG
+	end
+	if offAxis(rx) or offAxis(ry) or offAxis(rz) then
+		table.insert(issues, string.format(
+			"tilted off axis (%.0f, %.0f, %.0f) — verify forward axis",
+			rx, ry, rz))
+	end
+
+	if #issues > 0 then
+		failures = failures + 1
+		warn("[SELFTEST FAIL] " .. part:GetFullName())
+		for _, msg in ipairs(issues) do
+			warn("    - " .. msg)
+		end
+	end
+end
+
+local function walk(instance)
+	for _, child in ipairs(instance:GetChildren()) do
+		if child:IsA("MeshPart") then
+			checkMeshPart(child)
+		end
+		walk(child)
+	end
+end
+
+walk(Workspace)
+
+if failures == 0 then
+	print(string.format("[SELFTEST PASS] %d MeshParts checked, 0 violations.", checked))
+else
+	warn(string.format("[SELFTEST FAIL] %d violation(s) across %d MeshParts.", failures, checked))
+end

--- a/skills/goal-to-game/engines/roblox/tools/validate_mesh.py
+++ b/skills/goal-to-game/engines/roblox/tools/validate_mesh.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""validate_mesh.py — pre-import validation for the Roblox Studio path.
+
+Roblox validates geometry at the import boundary and refuses anything that
+fails. The three hard constraints (from
+https://create.roblox.com/docs/art/modeling/specifications) are:
+
+  1. <= 20,000 triangles per mesh (hard cap — Studio refuses anything over)
+  2. watertight / manifold (no exposed holes, open edges, non-manifold verts)
+  3. non-zero thickness (no infinitely thin sheets)
+
+This tool runs those checks BEFORE you import, so a rejected import never
+costs a round-trip through Studio. It is the "no manual mesh cleanup in
+between" step: run it on every grouped/decimated Thrixel asset and fix what it
+names before importing.
+
+Usage:
+  python validate_mesh.py <mesh.(glb|gltf|obj|stl|fbx)> [more meshes ...]
+
+  --max-triangles N   override the 20,000 cap (default: 20000)
+  --min-thickness M   override the thin-sheet threshold (default: 1e-4)
+
+Exit code 0 = every mesh passed. 1 = at least one failed (see the per-mesh
+report). 2 = a file could not be parsed at all.
+
+If `trimesh` is installed it is used for the authoritative watertight /
+manifold / euler-number check and for FBX. Without it the tool falls back to a
+stdlib-only check (triangle count + bounding-box thickness) and says so — the
+hole/backface check then needs `pip install trimesh` or a Blender pass.
+"""
+
+import argparse
+import base64
+import json
+import os
+import struct
+import sys
+
+MAX_TRIANGLES = 20000
+MIN_THICKNESS = 1e-4
+
+try:
+    import trimesh  # type: ignore
+    HAVE_TRIMESH = True
+except Exception:
+    HAVE_TRIMESH = False
+
+
+# --------------------------------------------------------------------------
+# stdlib-only parsers — triangle count + bounding box (thickness)
+# --------------------------------------------------------------------------
+
+def _bbox_thickness(mins, maxs):
+    extents = [maxs[i] - mins[i] for i in range(3)]
+    return min(extents), extents
+
+
+def parse_obj(path):
+    """Minimal Wavefront OBJ reader. Returns (triangles, mins, maxs)."""
+    verts = []
+    tris = 0
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if parts[0] == "v" and len(parts) >= 4:
+                verts.append(tuple(float(x) for x in parts[1:4]))
+            elif parts[0] == "f":
+                n = len(parts) - 1
+                if n >= 3:
+                    tris += n - 2  # fan triangulation of a convex n-gon
+    if not verts:
+        return 0, (0, 0, 0), (0, 0, 0)
+    xs = [v[0] for v in verts]
+    ys = [v[1] for v in verts]
+    zs = [v[2] for v in verts]
+    return tris, (min(xs), min(ys), min(zs)), (max(xs), max(ys), max(zs))
+
+
+def parse_stl_binary(path):
+    """Binary STL reader. Returns (triangles, mins, maxs)."""
+    with open(path, "rb") as f:
+        f.read(80)  # header
+        (count,) = struct.unpack("<I", f.read(4))
+        mins = [float("inf")] * 3
+        maxs = [float("-inf")] * 3
+        for _ in range(count):
+            tri = f.read(50)
+            if len(tri) < 50:
+                break
+            # 12-byte normal + 3 x (12-byte vertex)
+            for i in range(3):
+                off = 12 + i * 12
+                x, y, z = struct.unpack("<3f", tri[off:off + 12])
+                for axis, v in enumerate((x, y, z)):
+                    mins[axis] = min(mins[axis], v)
+                    maxs[axis] = max(maxs[axis], v)
+    if mins[0] == float("inf"):
+        return 0, (0, 0, 0), (0, 0, 0)
+    return count, tuple(mins), tuple(maxs)
+
+
+def _glb_triangle_count(gltf):
+    """Sum triangle counts across every mesh primitive in a glTF document."""
+    buffers = gltf.get("buffers", [])
+    accessors = gltf.get("accessors", [])
+    buffer_views = gltf.get("bufferViews", [])
+
+    total = 0
+    for mesh in gltf.get("meshes", []):
+        for prim in mesh.get("primitives", []):
+            idx_acc = prim.get("indices")
+            if idx_acc is not None:
+                total += accessors[idx_acc]["count"] // 3
+            else:
+                # non-indexed: triangle count from the POSITION accessor
+                pos = prim.get("attributes", {}).get("POSITION")
+                if pos is not None:
+                    total += accessors[pos]["count"] // 3
+    return total
+
+
+def _glb_bbox(gltf):
+    """Compute the world-space AABB from POSITION accessors (approximate: no
+    node transforms applied, which is the conservative choice for thickness —
+    a node scale could only make a thin sheet thinner or thicker, and a true
+    sheet stays a sheet under affine transform)."""
+    accessors = gltf.get("accessors", [])
+    buffer_views = gltf.get("bufferViews", [])
+    buffers = gltf.get("buffers", [])
+    mins = [float("inf")] * 3
+    maxs = [float("-inf")] * 3
+    found = False
+
+    for acc in accessors:
+        if acc.get("type") != "VEC3":
+            continue
+        bv_index = acc.get("bufferView")
+        if bv_index is None:
+            continue
+        bv = buffer_views[bv_index]
+        buf = buffers[bv.get("buffer", 0)]
+
+        data = None
+        uri = buf.get("uri")
+        if uri and uri.startswith("data:"):
+            data = base64.b64decode(uri.split(",", 1)[1])
+        if data is None:
+            # GLB binary chunk is passed in by the caller as _bin
+            data = buf.get("_bin")
+
+        if data is None:
+            continue
+        offset = (bv.get("byteOffset", 0) or 0) + (acc.get("byteOffset", 0) or 0)
+        count = acc.get("count", 0)
+        comp_type = acc.get("componentType", 5126)  # default FLOAT
+        if comp_type != 5126:
+            continue
+        for i in range(count):
+            off = offset + i * 12
+            if off + 12 > len(data):
+                break
+            x, y, z = struct.unpack_from("<3f", data, off)
+            mins[0] = min(mins[0], x); maxs[0] = max(maxs[0], x)
+            mins[1] = min(mins[1], y); maxs[1] = max(maxs[1], y)
+            mins[2] = min(mins[2], z); maxs[2] = max(maxs[2], z)
+            found = True
+    if not found:
+        return (0, 0, 0), (0, 0, 0)
+    return tuple(mins), tuple(maxs)
+
+
+def parse_glb(path):
+    """Parse GLB (binary glTF) or plain .gltf. Returns (triangles, mins, maxs)."""
+    if path.lower().endswith(".gltf"):
+        with open(path, "r", encoding="utf-8") as f:
+            gltf = json.load(f)
+        # resolve external buffer files relative to the gltf
+        for i, buf in enumerate(gltf.get("buffers", [])):
+            uri = buf.get("uri")
+            if uri and not uri.startswith("data:"):
+                bpath = os.path.join(os.path.dirname(os.path.abspath(path)), uri)
+                with open(bpath, "rb") as bf:
+                    buf["_bin"] = bf.read()
+    else:
+        with open(path, "rb") as f:
+            raw = f.read()
+        if raw[:4] != b"glTF":
+            raise ValueError("not a GLB file")
+        header = raw[:12]
+        json_len = struct.unpack_from("<I", raw, 12)[0]
+        gltf = json.loads(raw[20:20 + json_len].decode("utf-8"))
+        # attach the single binary chunk to buffer 0
+        bin_off = 20 + json_len
+        for i, buf in enumerate(gltf.get("buffers", [])):
+            if i == 0:
+                buf["_bin"] = raw[bin_off:bin_off + buf.get("byteLength", 0)]
+    return _glb_triangle_count(gltf), *_glb_bbox(gltf)
+
+
+# --------------------------------------------------------------------------
+# dispatch
+# --------------------------------------------------------------------------
+
+def load_mesh(path):
+    """Return (triangles, mins, maxs, extra) for a mesh file, or raise."""
+    ext = os.path.splitext(path)[1].lower()
+
+    if HAVE_TRIMESH and ext in (".fbx", ".glb", ".gltf", ".obj", ".stl"):
+        # authoritative path: trimesh gives triangle count, AABB and the
+        # watertight / manifold / euler-number checks all in one.
+        scene = trimesh.load(path, force="scene" if ext == ".glb" else None)
+        if isinstance(scene, trimesh.Scene):
+            meshes = list(scene.geometry.values())
+        else:
+            meshes = [scene]
+        return meshes, "trimesh"
+
+    if ext == ".obj":
+        tris, mins, maxs = parse_obj(path)
+        return [(tris, mins, maxs)], "stdlib"
+    if ext == ".stl":
+        tris, mins, maxs = parse_stl_binary(path)
+        return [(tris, mins, maxs)], "stdlib"
+    if ext in (".glb", ".gltf"):
+        tris, mins, maxs = parse_glb(path)
+        return [(tris, mins, maxs)], "stdlib"
+    if ext == ".fbx":
+        raise ValueError(
+            "FBX parsing needs `pip install trimesh` (and assimp). "
+            "Alternatively export the asset as .obj/.glb to validate it here."
+        )
+    raise ValueError("unsupported extension: %s" % ext)
+
+
+# --------------------------------------------------------------------------
+# checks
+# --------------------------------------------------------------------------
+
+def check(triangles, mins, maxs, max_tri, min_thickness, mode):
+    problems = []
+    if triangles > max_tri:
+        problems.append(
+            "triangle count %d exceeds %d (decimate with thrixel_reduce_triangles "
+            "or thrixel_group_parts target_triangles)" % (triangles, max_tri)
+        )
+    extents = [maxs[i] - mins[i] for i in range(3)]
+    thickness = min(extents) if extents else 0.0
+    if thickness < min_thickness:
+        problems.append(
+            "near-zero thickness (min extent %.6f) — add real thickness before import"
+            % thickness
+        )
+    return problems, thickness
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("meshes", nargs="+", help="one or more mesh files")
+    ap.add_argument("--max-triangles", type=int, default=MAX_TRIANGLES)
+    ap.add_argument("--min-thickness", type=float, default=MIN_THICKNESS)
+    args = ap.parse_args()
+
+    print("Roblox import-boundary validation")
+    print("  watertight/manifold check: %s" %
+          ("trimesh (authoritative)" if HAVE_TRIMESH else "UNAVAILABLE (pip install trimesh)"))
+    print()
+
+    any_fail = False
+    parse_fail = False
+
+    for path in args.meshes:
+        print("== %s" % path)
+        if not os.path.exists(path):
+            print("  [PARSE FAIL] file not found")
+            parse_fail = True
+            continue
+        try:
+            meshes, mode = load_mesh(path)
+        except Exception as e:
+            print("  [PARSE FAIL] %s" % e)
+            parse_fail = True
+            continue
+
+        for i, mesh in enumerate(meshes):
+            if mode == "trimesh":
+                if hasattr(mesh, "triangles"):
+                    tris = len(mesh.triangles)
+                else:
+                    tris = 0
+                if hasattr(mesh, "bounds"):
+                    mins = mesh.bounds[0].tolist()
+                    maxs = mesh.bounds[1].tolist()
+                else:
+                    mins = maxs = (0, 0, 0)
+                watertight = mesh.is_watertight if hasattr(mesh, "is_watertight") else None
+                winding = mesh.is_winding_consistent if hasattr(mesh, "is_winding_consistent") else None
+                euler = mesh.euler_number if hasattr(mesh, "euler_number") else None
+            else:
+                tris, mins, maxs = mesh
+                watertight = winding = euler = None
+
+            problems, thickness = check(tris, mins, maxs, args.max_triangles,
+                                        args.min_thickness, mode)
+            warnings = []
+            if mode == "trimesh":
+                if watertight is False:
+                    problems.append("not watertight — exposed holes / open edges")
+                if winding is False:
+                    problems.append("inconsistent winding — backfaces exposed")
+                if euler is not None and euler != 0:
+                    problems.append("non-zero Euler number %d — non-manifold geometry" % euler)
+            else:
+                warnings.append("watertight/manifold NOT verified (pip install trimesh "
+                                "for the authoritative check)")
+
+            if problems:
+                any_fail = True
+                print("  mesh %d: %d triangles, min-thickness %.4f  [FAIL]" %
+                      (i, tris, thickness))
+                for p in problems:
+                    print("    - %s" % p)
+                for w in warnings:
+                    print("    ! %s" % w)
+            else:
+                print("  mesh %d: %d triangles, min-thickness %.4f  [PASS]" %
+                      (i, tris, thickness))
+                for w in warnings:
+                    print("    ! %s" % w)
+        print()
+
+    print("=" * 60)
+    if parse_fail:
+        print("RESULT: one or more files could not be parsed (see above).")
+        return 2
+    if any_fail:
+        print("RESULT: FAIL — fix the named problems, then re-run before importing.")
+        return 1
+    print("RESULT: PASS — all meshes satisfy the Roblox import-boundary constraints.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds Roblox Studio as a third supported engine to the Goal to Game skill, alongside Unity and three.js.

A user with the skill installed can now type a prompt such as
`/thrixel:goal-to-game build a lighthouse-keeper game in Roblox where a storm rolls in each night`
and the coding agent gets a complete Roblox path: import format, the import-boundary validation
(20k-triangle cap, watertight, nonzero thickness), the material-slot -> SurfaceAppearance mapping,
the screenshot/verification loop, determinism and performance doctrine, and a place-contract template.

## Files

- `engines/roblox/roblox.md` — the engine rules (import boundary, material mapping, inspect + verification loops)
- `engines/roblox/PITFALLS.md` — import/appearance pitfalls that each cost an iteration round
- `engines/roblox/PROCESS.md` — the review-loop operating manual, adapted to Studio tools
- `engines/roblox/templates/ARCHITECTURE.md` — the Roblox place contract (ModuleScript registry, budgets, debug hooks)
- `SKILL.md` — registers Roblox Studio in the target-engine list and the skill description

## Executable tooling (not just prose)

The issue calls for "no manual mesh cleanup in between", so the import boundary and the in-Studio
checks are enforced by two shipped tools:

- `engines/roblox/tools/validate_mesh.py` — pre-import validator. Run on every grouped/decimated
  Thrixel asset *before* importing. Reports triangle count per mesh against the 20,000 cap, minimum
  thickness (thin-sheet check), and — with `trimesh` installed — watertightness, winding consistency
  and the Euler number. Exit 0 = safe to import; anything it names must be fixed first. This is the
  automated replacement for the manual Blender "Select Non-Manifold" pass.
- `engines/roblox/tools/selftest.server.lua` — in-Studio self-test. Drop into `ServerScriptService`
  and run: it walks every `MeshPart` and flags empty `MeshId`, near-zero thickness, missing
  `SurfaceAppearance`/`Texture`, unanchored/unwelded parts, and axis-tilted imports (forward-axis
  mistakes). Prints one `[SELFTEST PASS]` line on a clean run.

Both tools are referenced from the pre-import checklist and a dedicated "Tooling" section in
`roblox.md`, so the agent is told to run them, not merely to remember to look.

## Design decisions (per the issue constraints)

- **Import format**: FBX, the only format the Studio 3D Importer reads natively.
- **Geometry**: pre-import checklist (group -> decimate to <=20k via `thrixel_reduce_triangles` -> watertight/thickness check) because Roblox validates at the import boundary — now automated by `validate_mesh.py`.
- **Materials**: one `MeshPart` = one appearance, so Architect semantic slots are split back out by material in Blender before import and each gets its own `SurfaceAppearance` (5 PBR maps).
- **Verification**: Studio screenshot + play-test loop, with the three.js kit's determinism/performance doctrines adapted to what Roblox actually supports, plus the shipped `selftest.server.lua`.

Closes #3
