### PR TITLE
Add Roblox Studio engine guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Build beautiful games with high-quality 3D assets using [Thrixel](https://thrixe
 
 Claude Code handles the game logic and scene setup. Thrixel generates, organizes, and manages the 3D assets. Thrixel processes 3D creation in parallel so you can build your scene faster.
 
-Goal to Game currently supports **Unity** and **Three.js**. This page covers **Claude Code**, where every step below is tested.
+Goal to Game currently supports **Unity**, **Three.js**, and **Roblox Studio**. This page covers **Claude Code**, where every step below is tested.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/ThatCharlieK/READMEAssets/main/Thrixel-1prompt-to-game-readme.gif" width="600"/>
@@ -114,7 +114,7 @@ claude --permission-mode auto
 ```
 
 **Into Claude Code** (not the terminal), start the line with **`/thrixel:goal-to-game`**, then
-describe the game and name the engine (three.js or Unity):
+describe the game and name the engine (three.js, Unity, or Roblox Studio):
 
 ```text
 /thrixel:goal-to-game build a submarine exploration game in three.js set in a bright, vibrant tropical sea with coral and fish
@@ -211,7 +211,7 @@ Every asset generated through the Thrixel API is saved to your Thrixel workspace
 
 **Manage and Edit**: Visit [Thrixel Web App](https://thrixel.com/create) to view, manage, and edit your assets. If you make changes in the web app, ask your coding agent to pull the updated versions back into your game.
 
-**Engine Agnostic**: Because your assets are managed in Thrixel rather than tied to one codebase, you can also reuse them across projects and engines. For example, you can prototype in Three.js and later ask your agent to rebuild the game in Unity using the same asset library.
+**Engine Agnostic**: Because your assets are managed in Thrixel rather than tied to one codebase, you can also reuse them across projects and engines. For example, you can prototype in Three.js and later ask your agent to rebuild the game in Unity or Roblox Studio using the same asset library.
 
 **Parallel Processing**: Thrixel can manage and process jobs in parallel. Your coding agent can farm out parallel jobs to Thrixel while building out the logic of the game. Each [plan](https://thrixel.com/create/#upgrade) has a different concurrency limit.
 

--- a/skills/goal-to-game/SKILL.md
+++ b/skills/goal-to-game/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-to-game
-description: Generates polished, fully playable 3D game prototypes in Unity or three.js, with high quality (.glb) meshes generated through the Thrixel API. Use when the user wants to make a game, build a playable prototype, or generate 3D assets.
+description: Generates polished, fully playable 3D game prototypes in Unity, three.js, or Roblox Studio, with high quality meshes generated through the Thrixel API. Use when the user wants to make a game, build a playable prototype, or generate 3D assets.
 ---
 
 # Before anything else - update this skill
@@ -372,6 +372,7 @@ nearby files. Then read that engine's file **in full**:
 
 - **Unity** → [engines/unity.md](engines/unity.md)
 - **three.js / web** → [engines/threejs/threejs.md](engines/threejs/threejs.md)
+- **Roblox Studio / Luau / Rojo** → [engines/roblox.md](engines/roblox.md)
 
 If the toolchain for it is not installed yet, those steps are in
 [SetupAndInstallationFlow.md](SetupAndInstallationFlow.md) under "Install the engine toolchain".

--- a/skills/goal-to-game/engines/roblox.md
+++ b/skills/goal-to-game/engines/roblox.md
@@ -1,0 +1,280 @@
+# Roblox Studio
+
+Engine-specific rules for the Roblox Studio path. The shared Thrixel asset
+pipeline is in [../SKILL.md](../SKILL.md); this file covers only what differs
+for Roblox.
+
+Roblox is a good target for Goal to Game when the user wants a shareable place
+file, quick multiplayer affordances, mobile support, or Roblox-native physics and
+UI. It is a stricter import target than Unity or three.js: asset preparation,
+moderation, and Studio verification decide whether the result is usable.
+
+Before building, read [roblox/PITFALLS.md](roblox/PITFALLS.md).
+
+## Rules for Roblox game dev
+
+When developing in Roblox Studio, you MUST set up this checklist and verifiably
+check each item off:
+
+1. You MUST use Roblox Studio plus Rojo. If either cannot be found, stop and ask
+   the user to install or enable it. Do not fake a Roblox build with local HTML or
+   engine primitives.
+2. You MUST create a Rojo project and keep source in files, not only inside a
+   `.rbxl` place. The repo should have `default.project.json`, `src/`, and a
+   repeatable sync/run path.
+3. You MUST use `thrixel_group_parts` before download. Keep semantic material
+   slots as separate objects and pass moving parts through `keep_groups`.
+4. Download grouped Thrixel assets as `.fbx` for Roblox unless a specific asset
+   fails and `.gltf` imports more cleanly. Do not use `.obj` unless textures are
+   intentionally being rebuilt in Studio.
+5. Every imported mesh dependency MUST be below Roblox's 20,000-triangle per-mesh
+   limit, watertight, and nonzero thickness before the user is asked to import it.
+6. The skill MUST make imported assets visible through either the Open Cloud
+   upload plus Studio insertion path or the explicit manual Studio Importer
+   fallback below. Never leave the user with "upload it somehow."
+7. You MUST set `CollisionFidelity`, `RenderFidelity`, anchoring, collision
+   groups, and physical properties deliberately for every imported model.
+8. You MUST verify in Studio from several named camera positions and in Play Solo.
+   If Studio automation is not available on the machine, create the scripts,
+   project structure, and import manifest, then stop at the exact manual Studio
+   step and say what remains unverified.
+9. Prefer code-driven animation in Luau. Avoid detailed humanoid rigs unless the
+   user explicitly asks for avatar work.
+
+## Toolchain
+
+Check these before doing Roblox-specific work:
+
+```bash
+rojo --version
+```
+
+Roblox Studio itself is not reliably scriptable from a single cross-platform CLI.
+Look for it in the normal places and stop if it is absent:
+
+- macOS: `/Applications/RobloxStudio.app`
+- Windows: `%LOCALAPPDATA%\Roblox\Versions\*\RobloxStudioBeta.exe`
+
+Recommended optional tools:
+
+- Blender CLI for final mesh validation, decimation, origin cleanup, and format
+  conversion.
+- `run-in-roblox` or an equivalent Studio test runner if it is already present in
+  the project. Do not add a brittle runner unless you can prove it works.
+
+## Project shape
+
+Use Rojo's standard layout:
+
+```text
+default.project.json
+src/
+  client/
+  server/
+  shared/
+  assets/
+    manifests/
+    roblox/
+```
+
+`src/assets/manifests/` holds generated JSON manifests from the asset prep step.
+`src/assets/roblox/` holds Studio-side helper ModuleScripts that read those
+manifests after import. Do not commit user secrets, Open Cloud API keys, `.rbxl`
+binary files, or generated asset IDs unless the user explicitly wants those IDs
+in source.
+
+## Asset ingest
+
+Use this path for each Thrixel asset:
+
+1. Generate through the shared pipeline in `SKILL.md`.
+2. Run `thrixel_group_parts` before download:
+   - keep each material slot as a separate object so one `MeshPart` maps to one
+     appearance;
+   - pass `keep_groups` for moving parts such as wheels, doors, turrets,
+     propellers, drawers, levers, and hinges;
+   - name groups by gameplay purpose, not by generated mesh IDs.
+3. Download `.fbx`.
+4. Validate locally if Blender is available:
+   - no object above 20,000 triangles;
+   - no open boundary edges or obvious non-manifold geometry;
+   - each moving group origin is at its own geometric center or hinge point;
+   - transforms are applied and scale is normalized.
+5. Produce an import manifest with one record per expected Roblox `MeshPart`:
+
+```json
+{
+  "assetName": "storm_lighthouse",
+  "sourceFile": "build/import/storm_lighthouse.fbx",
+  "studsPerMeter": 3.571,
+  "parts": [
+    {
+      "name": "Body_Paint",
+      "semantic": "body",
+      "materialSlot": "Paint",
+      "trianglesMax": 20000,
+      "collision": "Hull",
+      "render": "Automatic",
+      "pivot": [0, 0, 0]
+    }
+  ]
+}
+```
+
+### Preferred import path
+
+If the user has a Roblox Open Cloud key with asset write permissions and a user
+or group creator ID, upload the `.fbx` as a Model asset. The Assets API accepts
+`.fbx`, `.gltf`, `.glb`, `.rbxm`, and `.rbxmx` for Model uploads and returns an
+operation. Poll that operation until it is done and record the returned Model
+asset ID.
+
+Then use a Studio-side build step to insert the owned model:
+
+```lua
+local InsertService = game:GetService("InsertService")
+
+local function loadOwnedModel(assetId: number): Model
+	local ok, result = pcall(function()
+		return InsertService:LoadAsset(assetId)
+	end)
+	assert(ok, ("failed to load model asset %d: %s"):format(assetId, tostring(result)))
+	local model = result:FindFirstChildWhichIsA("Model") or result
+	model.Parent = workspace.GeneratedAssets
+	return model
+end
+```
+
+After insertion, walk the `MeshPart` descendants, match them to the generated
+manifest by name, set properties, and emit a resolved manifest containing
+`MeshId`, texture asset IDs, pivots, bounding boxes, and moderation status if it
+is available.
+
+This path is preferred because it gives the agent an asset ID and a repeatable
+place-building script. It is still not a promise that everything can be fully
+headless: moderation, permission scope, and Studio security can block rendering
+or insertion. If any of those fail, use the fallback immediately.
+
+### Manual Studio Importer fallback
+
+If Open Cloud upload is unavailable or the returned Model cannot be resolved into
+usable `MeshPart` descendants, stop at a precise import handoff:
+
+1. Open Roblox Studio.
+2. Open or create the target place.
+3. Use Avatar / Import 3D or the Studio Importer to import the generated `.fbx`.
+4. Keep "Merge Meshes" off so material-slot objects remain separate MeshParts.
+5. Put the imported model under `Workspace/GeneratedAssets/<assetName>`.
+6. Run the generated Studio command or plugin script named in the manifest.
+
+The agent should prepare every file and script before this handoff. The human's
+manual work should be only the import operation that Studio refuses to expose
+reliably.
+
+## Materials and textures
+
+Roblox `MeshPart` does not support submesh-level material assignment. Treat each
+semantic material slot as a separate object before import. For rich materials,
+parent one `SurfaceAppearance` to the relevant `MeshPart` and set the maps at
+build time:
+
+- `ColorMap` for albedo/base color;
+- `NormalMap` for tangent-space normals;
+- `RoughnessMap` for roughness;
+- `MetalnessMap` for metalness;
+- `EmissiveMap` for glow masks when needed.
+
+Most `SurfaceAppearance` properties are preprocessing-heavy and should be
+treated as build-time data. Do not script live material swaps by mutating
+SurfaceAppearance maps every frame. For gameplay state changes, swap whole
+prepared MeshParts, toggle prebuilt variants, adjust lights, or use simple
+`BasePart` color/transparency changes.
+
+Roblox image uploads have size limits; keep source textures at or below 4096 on
+the long side by default and never above 8000 x 8000. If a texture shows blank:
+
+- first check moderation status and ownership, because pending assets can render
+  as missing even when references are correct;
+- then check the map is parented through `SurfaceAppearance`, not only left as a
+  file next to the mesh;
+- then verify the texture ID belongs to the same user or group that owns the
+  experience or is otherwise usable by it.
+
+## Scale and orientation
+
+Use studs deliberately. A practical default is:
+
+```text
+1 meter = 3.571 studs
+1 stud = 0.28 meters
+```
+
+Check every major asset next to a default R15 character before building gameplay
+around it. Thrixel forward axes can vary between assets, so determine forward
+from the actual mesh after import. Do not fix a sideways vehicle by rotating the
+visible mesh only; put it under a pivot `Model` or parent `Folder`, align the
+parent with gameplay forward, and keep moving child parts in local space.
+
+For ground placement:
+
+- set the model pivot to the intended gameplay origin;
+- move the model so the lowest collision-relevant point is on the floor plane;
+- keep decorative overhangs from defining the gameplay footprint.
+
+## Collision and performance
+
+Set these deliberately:
+
+- Decorative distant props: `CanCollide = false`, `RenderFidelity = Automatic`.
+- Walkable large static forms: simplified invisible collision parts plus visible
+  MeshParts with collision off.
+- Player-blocking props: `CollisionFidelity = Hull` or `Box` when possible.
+- Exact collision: use only for small, important interaction objects where Hull
+  is visibly wrong.
+
+Budget for mobile first unless the user says desktop-only:
+
+- keep imported MeshPart count low by grouping before download;
+- keep visible triangles under control per scene zone, not only per asset;
+- use streaming-friendly placement and avoid hundreds of unique texture assets
+  in the first view;
+- prefer Roblox `Terrain` and primitive Parts for large terrain masses, using
+  Thrixel for signature props, structures, vehicles, and interactables.
+
+## Verification loop
+
+Create a deterministic verification pass for every Roblox build:
+
+1. A Studio build script creates or updates the scene from Rojo source and import
+   manifests.
+2. A smoke test spawns the player, moves through the main route, triggers the
+   core interaction, and records a pass/fail summary in `ServerStorage` or a
+   generated output file.
+3. Named cameras cover at least:
+   - establishing view;
+   - close material view;
+   - player-scale view;
+   - collision/interaction view;
+   - mobile-framing view.
+4. Capture screenshots from Studio if automation is available. If not, leave the
+   cameras in `Workspace/VerificationCameras` and tell the user exactly which
+   screenshots remain manual.
+5. Inspect screenshots for missing moderated assets, invisible textures,
+   sideways orientation, floating meshes, over-large collision, frame-rate drops,
+   and UI overlap.
+
+A Roblox build is not done until the Rojo source syncs, the generated Studio
+scripts run without errors, and the manual or automated Studio inspection confirms
+that imported Thrixel assets are visible at the right scale.
+
+## Multiple concurrent game builds
+
+Skip this section unless the user has explicitly said several agents are building
+Roblox games on one machine.
+
+- Use different project folders and different Roblox places.
+- Do not share an Open Cloud API key file between writable projects; each project
+  should read secrets from the user's environment or local secret store.
+- Thrixel concurrency is account-wide, not per project.
+- Studio windows compete for focus and plugin state, so screenshot automation must
+  identify the place name and camera name in every output.

--- a/skills/goal-to-game/engines/roblox/PITFALLS.md
+++ b/skills/goal-to-game/engines/roblox/PITFALLS.md
@@ -1,0 +1,97 @@
+# Roblox Pitfalls
+
+Roblox can look like a simple import target, but the failures are usually at the
+boundary between generated assets, cloud moderation, Studio security, and mobile
+performance. Check this file before deciding a Roblox build is broken.
+
+## A. Import and asset IDs
+
+### The Open Cloud result is a Model ID, not your final mesh list
+
+The Assets API can upload an `.fbx` as a Model, but the useful runtime objects are
+the `MeshPart` descendants created when Studio inserts that model. Always resolve
+the uploaded Model inside Studio and write a resolved manifest. Do not assume the
+operation ID or Model asset ID is a `MeshId`.
+
+### Moderation can masquerade as a broken material
+
+Freshly uploaded meshes or textures can be referenced correctly and still render
+blank while moderation is pending. Check ownership and moderation before changing
+materials, UVs, or import format.
+
+### Studio importer settings matter
+
+If "Merge Meshes" is enabled, separate material-slot objects can collapse into a
+shape that Roblox cannot shade the way the Thrixel asset expects. Keep material
+slots separate unless the asset is deliberately single-material.
+
+## B. Geometry
+
+### One big beautiful mesh can fail import
+
+Roblox enforces a 20,000-triangle limit per individual mesh dependency and expects
+watertight, nonzero-thickness geometry. Grouping is not enough if one group stays
+too large. Split or decimate before import.
+
+### Shells are not solid gameplay objects
+
+Thin one-sided shells may look fine in Blender and fail collision, boolean
+operations, or import validation. If the asset is meant to collide, make it
+watertight or build separate invisible collision parts.
+
+### Origins decide whether moving parts feel broken
+
+If a wheel, hinge, turret, or door is not in `keep_groups`, it may rotate around
+the model root. Preserve it as its own object and verify the pivot in Studio
+before writing animation code.
+
+## C. Materials
+
+### SurfaceAppearance is not a runtime material system
+
+Treat `SurfaceAppearance` maps as baked build data. If gameplay needs stateful
+looks, prepare multiple assets or combine static SurfaceAppearance with simple
+runtime changes such as lights, particles, decals, transparency, or color.
+
+### One MeshPart gets one appearance
+
+Roblox does not give a single MeshPart several independently addressable material
+slots. Keep `Paint`, `Glass`, `Chrome`, `Rubber`, and similar semantic slots as
+separate imported objects.
+
+### Texture ownership matters
+
+A texture ID that works in one account or group may not render in another
+experience. Keep creator IDs consistent, and verify assets from the target place,
+not only from the upload script.
+
+## D. Scale, orientation, and controls
+
+### Stud conversion must be explicit
+
+Thrixel assets are not guaranteed to arrive at a Roblox character scale. Check
+against a default R15 rig and record `studsPerMeter` in the import manifest.
+
+### Forward is a gameplay contract
+
+Vehicles, doors, cameras, and projectiles need one shared idea of forward. Fix
+orientation at the parent model/pivot layer, not by scattering ad hoc rotations
+through movement scripts.
+
+## E. Performance
+
+### MeshPart count is often worse than triangle count
+
+Hundreds of tiny MeshParts cost draw calls, replication, physics broadphase, and
+Studio editing time. Group by material and gameplay motion before import.
+
+### Exact collision is expensive and rarely right
+
+Use invisible primitive collision for buildings, terrain, and large props. Reserve
+exact collision for small objects where the difference is obvious to the player.
+
+### Mobile catches first-view mistakes
+
+Roblox games are often played on phones. Verify the first playable view with
+mobile framing, modest graphics quality, and touch UI visible. A scene that only
+works on a desktop viewport is not done.


### PR DESCRIPTION
## Summary
- add a Roblox Studio engine guide for Goal to Game
- document the asset ingest path from Thrixel grouping/download to Roblox Open Cloud or Studio Importer fallback
- add Roblox-specific pitfalls for import, moderation, material slots, scale, collision, and mobile performance
- update the top-level skill routing and README supported-engine copy

## Validation
- git diff --check
- checked new relative links in roblox.md

Addresses #3.